### PR TITLE
Fixed calendar card to scroll with calendar

### DIFF
--- a/lib/generated_plugin_registrant.dart
+++ b/lib/generated_plugin_registrant.dart
@@ -1,0 +1,16 @@
+//
+// Generated file. Do not edit.
+//
+
+// ignore_for_file: directives_ordering
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:package_info_plus_web/package_info_plus_web.dart';
+
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+// ignore: public_member_api_docs
+void registerPlugins(Registrar registrar) {
+  PackageInfoPlugin.registerWith(registrar);
+  registrar.registerMessageHandler();
+}

--- a/lib/ui/calendar/calendar.dart
+++ b/lib/ui/calendar/calendar.dart
@@ -100,8 +100,7 @@ class Calendar extends StatelessWidget {
   Widget build(BuildContext context) {
     double calendarCardWidth = (MediaQuery.of(context).size.width -
             CalendarStyles.calendarTimeWidth -
-            20) /
-        7;
+            20) / 7;
 
     return Container(
         color: Colors.white,
@@ -110,85 +109,96 @@ class Calendar extends StatelessWidget {
           children: <Widget>[
             // calendar header
             Container(
-                height: CalendarStyles.calendarHeaderHeight,
-                padding: EdgeInsets.only(top: 20, bottom: 15),
-                decoration: BoxDecoration(
-                  border: Border(
-                    bottom: BorderSide(color: lightGray),
-                  ),
-                  color: Colors.white,
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.grey.withOpacity(0.05),
-                      spreadRadius: 1,
-                      blurRadius: 2,
-                      offset: Offset(0, 1), // changes position of shadow
-                    ),
-                  ],
+              height: CalendarStyles.calendarHeaderHeight,
+              padding: EdgeInsets.only(top: 20, bottom: 15),
+              decoration: BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(color: lightGray),
                 ),
-                child: Row(
-                  children: <Widget>[
-                    SizedBox(
-                      width: CalendarStyles.calendarTimeWidth,
-                    ),
-                    Expanded(
-                        child: Row(
+                color: Colors.white,
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.grey.withOpacity(0.05),
+                    spreadRadius: 1,
+                    blurRadius: 2,
+                    offset: Offset(0, 1), // changes position of shadow
+                  ),
+                ],
+              ),
+              child: Row(
+                children: <Widget>[
+                  SizedBox(
+                    width: CalendarStyles.calendarTimeWidth,
+                  ),
+                  Expanded(
+                    child: Row(
                       children: dayOfWeek
-                          .map((day) => Expanded(
-                                flex: 1,
-                                child: Container(
-                                    child: Center(
-                                        child: Text(day,
-                                            style: TextStyle(
-                                                fontSize: 10,
-                                                letterSpacing: -0.1)))),
-                              ))
-                          .toList(),
-                    ))
-                  ],
-                )),
-
-            Expanded(
-                child: Stack(children: <Widget>[
+                        .map((day) => Expanded(
+                          flex: 1,
+                          child: Center(
+                            child: Text(
+                              day,
+                              style: const TextStyle(
+                                fontSize: 10,
+                                letterSpacing: -0.1
+                              )
+                            )
+                          )
+                        ),)
+                        .toList(),
+                    )
+                  )
+                ],
+              )),
               // calendar body
-              ListView.builder(
-                  itemCount: times.length,
-                  // padding: EdgeInsets.symmetric(vertical: 8),
-                  itemBuilder: (BuildContext context, int index) {
-                    return Container(
-                        height: CalendarStyles.calendarRowHeight,
-                        margin: EdgeInsets.all(0),
-                        padding: EdgeInsets.all(0),
-                        decoration: BoxDecoration(
-                          border: Border(
-                            bottom: BorderSide(color: lightGray),
-                          ),
+              Expanded(
+                child: ListView(
+                  shrinkWrap: true,
+                  children: <Widget> [
+                    Stack(
+                      children: <Widget>[
+                        // calendar body
+                        Column(
+                          children: <Widget>[
+                            ...times.map((time) {
+                              return Container(
+                                height: CalendarStyles.calendarRowHeight,
+                                margin: EdgeInsets.all(0),
+                                padding: EdgeInsets.all(0),
+                                decoration: BoxDecoration(
+                                  border: Border(
+                                    bottom: BorderSide(color: lightGray),
+                                  ),
+                                ),
+                                child: Row(
+                                    mainAxisAlignment: MainAxisAlignment.start,
+                                    children: <Widget>[
+                                      SizedBox(
+                                          width: CalendarStyles.calendarTimeWidth,
+                                          child: Center(
+                                            child: Text(time,
+                                                style: TextStyle(fontSize: 10)),
+                                          ))
+                                    ]));
+                            }).toList(),
+                          ],
                         ),
-                        child: Row(
-                            mainAxisAlignment: MainAxisAlignment.start,
-                            children: <Widget>[
-                              SizedBox(
-                                  width: CalendarStyles.calendarTimeWidth,
-                                  child: Center(
-                                    child: Text(times[index],
-                                        style: TextStyle(fontSize: 10)),
-                                  ))
-                            ]));
-                  }),
-
-              CalendarCard('10:00', '10:50', '2020-06-06T', 0, 'LE', 'CSE 110',
-                  'Center 109'),
-              CalendarCard('10:00', '10:50', '2020-06-06T', 2, 'LE', 'CSE 110',
-                  'Center 109'),
-              CalendarCard('10:00', '10:50', '2020-06-06T', 4, 'LE', 'CSE 110',
-                  'Center 109'),
-
-              CalendarCard('11:00', '12:20', '2020-06-06T', 1, 'DI', 'CSE 100',
-                  'WLH 109'),
-              CalendarCard('11:00', '12:20', '2020-06-06T', 3, 'DI', 'CSE 100',
-                  'WLH 109'),
-            ])),
-            BuildInfo(),
+                        CalendarCard('10:00', '10:50', '2020-06-06T', 0, 'LE', 'CSE 120',
+                          'Center 109'),
+                        CalendarCard('10:00', '10:50', '2020-06-06T', 2, 'LE', 'CSE 120',
+                          'Center 109'),
+                        CalendarCard('10:00', '10:50', '2020-06-06T', 4, 'LE', 'CSE 120',
+                          'Center 109'),
+                        CalendarCard('11:00', '12:20', '2020-06-06T', 1, 'DI', 'CSE 100',
+                          'WLH 109'),
+                        CalendarCard('11:00', '12:20', '2020-06-06T', 3, 'DI', 'CSE 100',
+                          'WLH 109'),
+                      ]
+                    )
+                  ]
+                ),
+              ),
+              BuildInfo(),
           ],
         ));
   }

--- a/lib/ui/calendar/calendar_card.dart
+++ b/lib/ui/calendar/calendar_card.dart
@@ -19,7 +19,6 @@ class _CalendarCardState extends State<CalendarCard> {
 
   double getTimeDifference(String start, String end, String prefix) {
     double diff = DateTime.parse(prefix + end).difference(DateTime.parse(prefix + start)).inMinutes.toDouble();
-    print(diff.toString());
     return diff;
   }
   
@@ -43,7 +42,6 @@ class _CalendarCardState extends State<CalendarCard> {
           decoration: BoxDecoration(
             color: Colors.white,
             borderRadius: BorderRadius.all(Radius.circular(2.0)),
-            // border: Border.all(width: 1, color: )
             boxShadow: [
               BoxShadow(
                 color: Colors.black.withOpacity(0.25),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -106,21 +106,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   package_info_plus:
     dependency: "direct main"
     description:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   package_info_plus_linux:
     dependency: transitive
     description:
@@ -188,7 +188,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -223,7 +223,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -237,7 +237,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:
@@ -246,5 +246,5 @@ packages:
     source: hosted
     version: "2.0.5"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"


### PR DESCRIPTION
## Summary
A [bug](https://github.com/UCSD/webreg-mobile/issues/4#issuecomment-1031731394) report by @kevdesilva01 says that the calendar cards do not scroll along with the calendar. The bug has been fixed.

## Changelog
<!--
    Help reviewers by writing your own changelog entry.

    CATEGORIES: [General, Android, iOS, or Internal]
    TYPES:      [Add, Change, Fix, or Remove]
    MESSAGE:    What and why

    Examples:
    1. [General] [Add] - Add promo banner capability
    2. [iOS] [Change] - Smooth transitions when navigating between tabs
    3. [Android] [Fix] - Fix a bug causing the user to be logged out
-->
[Webreg] [Fix] - Fixed calendar cards to scroll with the calendar


## Test Plan
<!--
    Explain the steps taken to test this update.
    Include screenshots and/or videos if the pull request changes the user interface.
-->

The bug fix has been tested with the Calendar view and the Finals view where calendars are shown. The cards in both views scroll correctly with the calendars (see screen recording).

https://user-images.githubusercontent.com/35356954/152858402-6e186ed7-1729-48fb-b432-afec2de98c33.mov


